### PR TITLE
Add support for juju 3.4 status relation format

### DIFF
--- a/jujulint/model_input.py
+++ b/jujulint/model_input.py
@@ -244,7 +244,13 @@ class JujuStatusFile(BaseFile):
         apps_related = set()
         for app in apps:
             relations = self.applications_data.get(app, {}).get("relations", {})
-            apps_related.update(relations.get(endpoint, []))
+            endpoints = relations.get(endpoint, [])
+            # since juju 3.4, this is a dict instead of a string,
+            # so convert to a string.
+            for i in range(len(endpoints)):
+                if isinstance(endpoints[i], dict):
+                    endpoints[i] = endpoints[i]["related-application"]
+            apps_related.update(endpoints)
         return apps_related
 
     def filter_lxd_on_machine(self, machine: str) -> Set:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -430,7 +430,11 @@ def parsed_yaml_status_juju34():
                 "charm-name": "nrpe",
                 "relations": {
                     "nrpe-external-master": [
-                        {"related-application": "keystone", "interface": "nrpe-external-master", "scope": "container"},
+                        {
+                            "related-application": "keystone",
+                            "interface": "nrpe-external-master",
+                            "scope": "container",
+                        },
                     ],
                 },
                 "endpoint-bindings": {
@@ -447,7 +451,11 @@ def parsed_yaml_status_juju34():
                 "charm-name": "nrpe",
                 "relations": {
                     "nrpe-external-master": [
-                        {"related-application": "elasticsearch", "interface": "nrpe-external-master", "scope": "container"},
+                        {
+                            "related-application": "elasticsearch",
+                            "interface": "nrpe-external-master",
+                            "scope": "container",
+                        },
                     ],
                     "general-info": ["ubuntu"],
                 },
@@ -464,9 +472,15 @@ def parsed_yaml_status_juju34():
                 "application-status": {"current": "active"},
                 "charm": "cs:ubuntu-18",
                 "charm-name": "ubuntu",
-                "relations": {"juju-info": [
-                    {"related-application": "nrpe-host", "interface": "juju-info", "scope": "container"},
-                ]},
+                "relations": {
+                    "juju-info": [
+                        {
+                            "related-application": "nrpe-host",
+                            "interface": "juju-info",
+                            "scope": "container",
+                        },
+                    ]
+                },
                 "endpoint-bindings": {
                     "": "external-space",
                     "certificates": "external-space",
@@ -490,7 +504,11 @@ def parsed_yaml_status_juju34():
                 "charm-name": "keystone",
                 "relations": {
                     "nrpe-external-master": [
-                        {"related-application": "nrpe-container", "interface": "nrpe-external-master", "scope": "container"},
+                        {
+                            "related-application": "nrpe-container",
+                            "interface": "nrpe-external-master",
+                            "scope": "container",
+                        },
                     ],
                 },
                 "endpoint-bindings": {
@@ -530,7 +548,11 @@ def parsed_yaml_status_juju34():
                 "charm-name": "elasticsearch",
                 "relations": {
                     "nrpe-external-master": [
-                        {"related-application": "nrpe-host", "interface": "nrpe-external-master", "scope": "container"},
+                        {
+                            "related-application": "nrpe-host",
+                            "interface": "nrpe-external-master",
+                            "scope": "container",
+                        },
                     ],
                 },
                 "endpoint-bindings": {

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -244,6 +244,7 @@ def rules_files():
 @pytest.fixture
 def input_files(
     parsed_yaml_status,
+    parsed_yaml_status_juju34,
     parsed_yaml_bundle,
     parsed_hyper_converged_yaml_status,
     parsed_hyper_converged_yaml_bundle,
@@ -252,6 +253,10 @@ def input_files(
         "juju-status": JujuStatusFile(
             applications_data=parsed_yaml_status["applications"],
             machines_data=parsed_yaml_status["machines"],
+        ),
+        "juju-status-34": JujuStatusFile(
+            applications_data=parsed_yaml_status_juju34["applications"],
+            machines_data=parsed_yaml_status_juju34["machines"],
         ),
         "juju-status-hyper-converged": JujuStatusFile(
             applications_data=parsed_hyper_converged_yaml_status["applications"],
@@ -376,6 +381,157 @@ def parsed_yaml_status():
                 "charm-name": "elasticsearch",
                 "relations": {
                     "nrpe-external-master": ["nrpe-host"],
+                },
+                "endpoint-bindings": {
+                    "": "oam-space",
+                    "client": "oam-space",
+                    "data": "oam-space",
+                    "logs": "oam-space",
+                    "nrpe-external-master": "oam-space",
+                    "peer": "oam-space",
+                },
+                "units": {
+                    "elasticsearch/0": {
+                        "machine": "0",
+                        "subordinates": {
+                            "nrpe-host/0": {
+                                "workload-status": {
+                                    "current": "active",
+                                }
+                            }
+                        },
+                    }
+                },
+            },
+        },
+        "machines": {
+            "0": {
+                "series": "focal",
+            },
+            "1": {
+                "series": "focal",
+                "containers": {
+                    "1/lxd/0": {
+                        "series": "focal",
+                    }
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture
+def parsed_yaml_status_juju34():
+    """Representation of juju 3.4 status input to test relations checks."""
+    return {
+        "applications": {
+            "nrpe-container": {
+                "charm": "cs:nrpe-61",
+                "charm-name": "nrpe",
+                "relations": {
+                    "nrpe-external-master": [
+                        {"related-application": "keystone", "interface": "nrpe-external-master", "scope": "container"},
+                    ],
+                },
+                "endpoint-bindings": {
+                    "general-info": "",
+                    "local-monitors": "",
+                    "monitors": "oam-space",
+                    "nrpe": "",
+                    "nrpe-external-master": "",
+                },
+                "subordinate-to": ["keystone"],
+            },
+            "nrpe-host": {
+                "charm": "cs:nrpe-67",
+                "charm-name": "nrpe",
+                "relations": {
+                    "nrpe-external-master": [
+                        {"related-application": "elasticsearch", "interface": "nrpe-external-master", "scope": "container"},
+                    ],
+                    "general-info": ["ubuntu"],
+                },
+                "endpoint-bindings": {
+                    "general-info": "",
+                    "local-monitors": "",
+                    "monitors": "oam-space",
+                    "nrpe": "",
+                    "nrpe-external-master": "",
+                },
+                "subordinate-to": ["elasticsearch", "ubuntu"],
+            },
+            "ubuntu": {
+                "application-status": {"current": "active"},
+                "charm": "cs:ubuntu-18",
+                "charm-name": "ubuntu",
+                "relations": {"juju-info": [
+                    {"related-application": "nrpe-host", "interface": "juju-info", "scope": "container"},
+                ]},
+                "endpoint-bindings": {
+                    "": "external-space",
+                    "certificates": "external-space",
+                },
+                "units": {
+                    "ubuntu/0": {
+                        "machine": "1",
+                        "workload-status": {"current": "active"},
+                        "subordinates": {
+                            "nrpe-host/0": {
+                                "workload-status": {
+                                    "current": "active",
+                                }
+                            }
+                        },
+                    }
+                },
+            },
+            "keystone": {
+                "charm": "cs:keystone-309",
+                "charm-name": "keystone",
+                "relations": {
+                    "nrpe-external-master": [
+                        {"related-application": "nrpe-container", "interface": "nrpe-external-master", "scope": "container"},
+                    ],
+                },
+                "endpoint-bindings": {
+                    "": "oam-space",
+                    "admin": "external-space",
+                    "certificates": "oam-space",
+                    "cluster": "oam-space",
+                    "domain-backend": "oam-space",
+                    "ha": "oam-space",
+                    "identity-admin": "oam-space",
+                    "identity-credentials": "oam-space",
+                    "identity-notifications": "oam-space",
+                    "identity-service": "oam-space",
+                    "internal": "internal-space",
+                    "keystone-fid-service-provider": "oam-space",
+                    "keystone-middleware": "oam-space",
+                    "nrpe-external-master": "oam-space",
+                    "public": "external-space",
+                    "shared-db": "internal-space",
+                    "websso-trusted-dashboard": "oam-space",
+                },
+                "units": {
+                    "keystone/0": {
+                        "machine": "1/lxd/0",
+                        "subordinates": {
+                            "nrpe-container/0": {
+                                "workload-status": {
+                                    "current": "active",
+                                }
+                            }
+                        },
+                    }
+                },
+            },
+            "elasticsearch": {
+                "charm": "cs:elasticsearch-39",
+                "charm-name": "elasticsearch",
+                "relations": {
+                    "nrpe-external-master": [
+                        {"related-application": "nrpe-host", "interface": "nrpe-external-master", "scope": "container"},
+                    ],
                 },
                 "endpoint-bindings": {
                     "": "oam-space",

--- a/tests/unit/test_input.py
+++ b/tests/unit/test_input.py
@@ -142,6 +142,13 @@ def test_check_app_endpoint_existence(
             {"keystone", "elasticsearch"},
         ),  # all apps with nrpe-external-master
         (
+            "juju-status-34",
+            "nrpe",
+            "*",
+            "nrpe-external-master",
+            {"keystone", "elasticsearch"},
+        ),  # all apps with nrpe-external-master
+        (
             "juju-bundle",
             "nrpe",
             "*",
@@ -156,6 +163,13 @@ def test_check_app_endpoint_existence(
             {"keystone"},
         ),  # check if keystone has nrpe-external-master
         (
+            "juju-status-34",
+            "nrpe",
+            "keystone",
+            "nrpe-external-master",
+            {"keystone"},
+        ),  # check if keystone has nrpe-external-master
+        (
             "juju-bundle",
             "nrpe",
             "keystone",
@@ -164,6 +178,13 @@ def test_check_app_endpoint_existence(
         ),  # check if keystone has nrpe-external-master
         (
             "juju-status",
+            "nrpe",
+            "ubuntu",
+            "nrpe-external-master",
+            set(),
+        ),  # check if ubuntu has nrpe-external-master
+        (
+            "juju-status-34",
             "nrpe",
             "ubuntu",
             "nrpe-external-master",
@@ -192,10 +213,13 @@ def test_filter_by_app_and_endpoint(
     "input_file_type, endpoint, expected_output",
     [
         ("juju-status", "nrpe-external-master", {"keystone", "elasticsearch"}),
+        ("juju-status-34", "nrpe-external-master", {"keystone", "elasticsearch"}),
         ("juju-bundle", "nrpe-external-master", {"keystone", "elasticsearch"}),
         ("juju-status", "general-info", {"ubuntu"}),
+        ("juju-status-34", "general-info", {"ubuntu"}),
         ("juju-bundle", "general-info", {"ubuntu"}),
         ("juju-status", "monitors", set()),
+        ("juju-status-34", "monitors", set()),
         ("juju-bundle", "monitors", set()),
     ],
 )

--- a/tests/unit/test_relations.py
+++ b/tests/unit/test_relations.py
@@ -14,10 +14,15 @@ RELATIONS = [["*:nrpe-external-master", "nrpe:nrpe-external-master"]]
     "correct_relation, input_file_type",
     [
         (RELATIONS, "juju-status"),
+        (RELATIONS, "juju-status-34"),
         (RELATIONS, "juju-bundle"),
         (
             [["nrpe:nrpe-external-master", "*:nrpe-external-master"]],
             "juju-status",
+        ),  # inverting sequence doesn't change the endpoint
+        (
+            [["nrpe:nrpe-external-master", "*:nrpe-external-master"]],
+            "juju-status-34",
         ),  # inverting sequence doesn't change the endpoint
         (
             [["nrpe:nrpe-external-master", "*:nrpe-external-master"]],
@@ -26,6 +31,10 @@ RELATIONS = [["*:nrpe-external-master", "nrpe:nrpe-external-master"]]
         (
             [["nrpe:nrpe-external-master", "keystone:nrpe-external-master"]],
             "juju-status",
+        ),  # able to find specific app relation
+        (
+            [["nrpe:nrpe-external-master", "keystone:nrpe-external-master"]],
+            "juju-status-34",
         ),  # able to find specific app relation
         (
             [["nrpe:nrpe-external-master", "keystone:nrpe-external-master"]],
@@ -227,6 +236,12 @@ def test_relation_rule_unknown_charm(mocker, input_files, input_file_type):
             [["foo:juju-info", "bar:juju-info"]],
             True,
             False,
+            "juju-status-34",
+        ),  # app doesn't exist
+        (
+            [["foo:juju-info", "bar:juju-info"]],
+            True,
+            False,
             "juju-bundle",
         ),  # app doesn't exist
         (
@@ -234,6 +249,12 @@ def test_relation_rule_unknown_charm(mocker, input_files, input_file_type):
             False,
             True,
             "juju-status",
+        ),  # endpoint doesn't exist
+        (
+            [["keystone:bar", "nrpe-host:foo"]],
+            False,
+            True,
+            "juju-status-34",
         ),  # endpoint doesn't exist
         (
             [["keystone:bar", "nrpe-host:foo"]],
@@ -275,6 +296,12 @@ def test_relation_rule_unknown_app_endpoint(
             {"3": {"series": "focal"}, "2": {"series": "bionic"}},
             ["2", "3"],
             RELATIONS,
+            "juju-status-34",
+        ),
+        (
+            {"3": {"series": "focal"}, "2": {"series": "bionic"}},
+            ["2", "3"],
+            RELATIONS,
             "juju-bundle",
         ),
         # empty relations is able to run ubiquitous check
@@ -283,6 +310,12 @@ def test_relation_rule_unknown_app_endpoint(
             ["2", "3"],
             [[]],
             "juju-status",
+        ),
+        (
+            {"3": {"series": "focal"}, "2": {"series": "bionic"}},
+            ["2", "3"],
+            [[]],
+            "juju-status-34",
         ),
         (
             {"3": {"series": "focal"}, "2": {"series": "bionic"}},


### PR DESCRIPTION
Newer juju versions format the relation information as a dict, rather than a string.
Add support for this, in a backwards compatible manner.

Fixes: #286