### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,23 +18,26 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [[ubuntu-22.04]]
-    outputs:
-      snap: ${{ steps.build.outputs.snap }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Complete git history is required to generate the version from git tags.
-      - uses: canonical/action-build@v1
-        id: build
+
       - name: Determine system architecture
         run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v4
+
+      - name: Download built snap from the build job in check workflow
+        uses: actions/download-artifact@v4
         with:
           name: snap_${{ env.SYSTEM_ARCH }}
           path: ${{ steps.build.outputs.snap }}
+
+      - name: Find the downloaded snap file
+        run: echo "SNAP_FILE=$(find . -name "*.snap")" >> $GITHUB_ENV
+
       - uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
-          snap: ${{ steps.build.outputs.snap }}
+          snap: ${{ env.SNAP_FILE }}
           release: latest/edge

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: snap_${{ env.SYSTEM_ARCH }}
-          path: ${{ steps.build.outputs.snap }}
 
       - name: Find the downloaded snap file
         run: echo "SNAP_FILE=$(find . -name "*.snap")" >> $GITHUB_ENV


### PR DESCRIPTION
The check workflow uploads the snap,
which conflicts with uploading the snap from the release workflow. So we can reuse the built snap from the check workflow, saving needing to rebuild the snap,
and avoiding the conflict.

Based on work in https://github.com/canonical/dcgm-snap/pull/36