### PR TITLE
Slight change to fix the wrong wording in lint-rules file not found error

### DIFF
--- a/jujulint/cli.py
+++ b/jujulint/cli.py
@@ -113,7 +113,7 @@ class Cli:
                     "{}/{}".format(self.config.config_dir(), arg)
                 )
             else:
-                self.logger.error("Cloud not locate rules file {}".format(arg))
+                self.logger.error("Could not locate rules file {}".format(arg))
                 sys.exit(1)
 
         return validated_rules_file_args


### PR DESCRIPTION
This occurs when lint-rules.yaml file is not found while trying to `juju-lint`:

```
ubuntu@jumphost:~$ juju-lint cos-status.yaml
2024-11-11 07:09:12 [ERROR] Cloud not locate rules file lint-rules.yaml
```

I believe the correct word should be "could" here.