### PR TITLE
Fix lint

### DIFF
--- a/jujulint/checks/hyper_converged.py
+++ b/jujulint/checks/hyper_converged.py
@@ -9,7 +9,7 @@ from jujulint.model_input import JujuBundleFile, JujuStatusFile
 
 # see LP#1990885
 def check_hyper_converged(
-    input_file: Union[JujuBundleFile, JujuStatusFile]
+    input_file: Union[JujuBundleFile, JujuStatusFile],
 ) -> DefaultDict[str, DefaultDict[str, set]]:
     """Check if other services are collocated with nova/osd with masakari.
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,6 @@ deps =
     yamllint
 
 [testenv:reformat]
-envdir = {toxworkdir}/lint
 commands =
     black .
     isort .


### PR DESCRIPTION
This should fix the lint failures seen on the weekly test on main: https://github.com/canonical/juju-lint/actions/runs/13211906118/job/36886422422

Also remove the unnecessary envdir option in tox.ini. Using the option in this way to share environments is not recommended.
Also, with the option, tox will recreate the environment every time you switch between lint and reformat,
which is not efficient.

